### PR TITLE
Update qaoa.ipynb

### DIFF
--- a/content/ch-applications/qaoa.ipynb
+++ b/content/ch-applications/qaoa.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "where $x \\in S$, is a discreet variable and $C : D \\rightarrow \\mathbb{R}$ is the cost function. That maps from some domain $S$ in to the real numbers $\\mathbb{R}$. The variable $x$ can be subject to a set of constraints and lies within the set $S \\subset D$ of feasible points.\n",
     "\n",
-    "In binary combinatorial optimization problems, the cost function can typically be expressed as a sum of terms that only involve a subsets $Q \\subset[n]$ of the $n$ bits in the string $x \\in \\{0,1\\}^n$ . The cost function $C$ typically written in the canonical form\n",
+    "In binary combinatorial optimization problems, the cost function can typically be expressed as a sum of terms that only involve a subset $Q \\subset[n]$ of the $n$ bits in the string $x \\in \\{0,1\\}^n$ . The cost function $C$ typically written in the canonical form\n",
     "\n",
     "\n",
     "\n",


### PR DESCRIPTION
4.1.3 Grammar error fix in Introduction ("a subsets Q" to "a subset Q")

<!--- 
Your PR title should start with the number of the chapter(s) 
your PR affects. E.g "4.5, 6.3 Fixed misspelling of 'transform'"
The exception is if you change a large number of chapters or none
at all.
--->
# Changes made
<!--- Please state what you did --->
Replaced "a subsets Q" with "a subset Q"
# Justification
<!--- Please explain why this change is necessary. If changing technical
details / equations, do not asssume the justification is obvious --->
Grammar error.